### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Unreleased
 ==========
 
-1.1.0 (2021-02-22)
+1.1.0 (2022-02-22)
 ==================
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 
 Unreleased
 ==========
+
+1.1.0 (2021-02-22)
+==================
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added
 * Python 3.5 and 3.6 support removed

--- a/djangocms_url_manager/__init__.py
+++ b/djangocms_url_manager/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.0.0"
+__version__ = "1.1.0"
 
 default_app_config = "djangocms_url_manager.apps.UrlManagerConfig"

--- a/djangocms_url_manager/__init__.py
+++ b/djangocms_url_manager/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.0.dev2"
+__version__ = "2.0.0"
 
 default_app_config = "djangocms_url_manager.apps.UrlManagerConfig"


### PR DESCRIPTION
* Python 3.8, 3.9 support added
* Django 3.0, 3.1 and 3.2 support added
* Python 3.5 and 3.6 support removed
* Django 1.11 support removed

I was tempted to release this as 2.0.0 but as a major change with versioning has already happened in 1.0.0 we are already on a path of major changes being made. 