### PR TITLE
Feature/add burger menu to changelist

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: Added support for burger menu in actions column of changelist view.
 
 1.1.0 (2022-02-22)
 ==================

--- a/djangocms_url_manager/admin.py
+++ b/djangocms_url_manager/admin.py
@@ -71,3 +71,11 @@ class UrlAdmin(*url_admin_classes):
         return super().change_view(
             request, object_id, form_url, extra_context=extra_context,
         )
+
+    def changelist_view(self, request, *args, extra_context=None, **kwargs):
+        extra_context = extra_context or {}
+        # Provide additional context to the changelist view:
+        extra_context['is_versioning_enabled'] = is_versioning_enabled()
+        return super().changelist_view(
+            request, *args, extra_context=extra_context, **kwargs
+        )

--- a/djangocms_url_manager/templates/admin/djangocms_url_manager/url/change_list.html
+++ b/djangocms_url_manager/templates/admin/djangocms_url_manager/url/change_list.html
@@ -1,0 +1,18 @@
+{% extends "admin/change_list.html" %}
+{% load cms_static static %}
+
+{% block extrahead %}
+    {{ block.super }}
+
+    {% if is_versioning_enabled %}
+        {# INFO: To avoid conflicts with adminstyle css we need to add styles here #}
+        {# instead of inside "extrastyle" block or admin Media class. #}
+        <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.base.css' %}">
+        <link rel="stylesheet" href="{% static_with_version 'cms/css/cms.pagetree.css' %}">
+        
+        {# INFO: versioning_static_url_prefix variable is used in versioning actions.js #}
+        <script>
+            let versioning_static_url_prefix = "{% static "djangocms_versioning/" %}";
+        </script>
+    {% endif %}
+{% endblock extrahead %}


### PR DESCRIPTION
Added support for burger menu in actions column of changelist view, if djangocms_versioning is enabled.