### PR TITLE
fix: Change util import from depreciated collections.Iterable to collections.abc.Iterable

### DIFF
--- a/djangocms_url_manager/utils.py
+++ b/djangocms_url_manager/utils.py
@@ -1,5 +1,6 @@
 import functools
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from functools import lru_cache
 
 from django.apps import apps


### PR DESCRIPTION
Since Python 3.10.x collections.Iterable has been depreciated, by changing the import to collections.abc.Iterable we solve this problem, and it is backwards compatible. 