### PR TITLE
Fix: Drop support for Python 3.6, 3.7 and Django 2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, ]  # latest release minus two
+        python-version: [ 3.8, 3.9, ]  # latest release minus two
         requirements-file: [
-            dj22_cms40.txt,
             dj32_cms40.txt,
         ]
         os: [
@@ -43,9 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, ]  # latest release minus two
+        python-version: [ 3.8, 3.9, ]  # latest release minus two
         requirements-file: [
-            dj22_cms40.txt,
             dj32_cms40.txt,
         ]
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Installation
 Requirements
 ============
 
-django CMS URL Manager requires that you have a django CMS 4.0 or higher.
+django CMS URL Manager requires that you have a django CMS 4.0 or higher project already set up and running.
 
 For those who wish to use this app on Django <3.2 or Python <3.8 use the 4.0.x branch.
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,9 @@ Installation
 Requirements
 ============
 
-django CMS URL Manager requires that you have a django CMS 3.5 (or higher) project already running and set up.
+django CMS URL Manager requires that you have a django CMS 4.0 or higher.
+
+For those who wish to use this app on Django <3.2 or Python <3.8 use the 4.0.x branch.
 
 
 To install

--- a/djangocms_url_manager/utils.py
+++ b/djangocms_url_manager/utils.py
@@ -1,5 +1,6 @@
 import functools
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from functools import lru_cache
 
 from django.apps import apps

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@ INSTALL_REQUIREMENTS = [
     "Django>=2.2,<4.0",
     "django-cms",
     "djangocms-attributes-field",
-    "django-app-helper",
-    "factory-boy",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,8 @@ INSTALL_REQUIREMENTS = [
     "Django>=2.2,<4.0",
     "django-cms",
     "djangocms-attributes-field",
+    "django-app-helper",
+    "factory-boy",
 ]
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -5,6 +5,7 @@ from djangocms_url_manager.test_utils.polls.utils import (
     get_published_pages_objects,
 )
 
+
 CMS_CONFIRM_VERSION4 = True
 EXTRA_INSTALLED_APPS = ["app_helper"]
 ENABLE_VERSIONING = bool(os.environ.get("ENABLE_VERSIONING", True))

--- a/test_settings.py
+++ b/test_settings.py
@@ -6,7 +6,6 @@ from djangocms_url_manager.test_utils.polls.utils import (
 )
 
 
-CMS_CONFIRM_VERSION4 = True
 EXTRA_INSTALLED_APPS = ["app_helper"]
 ENABLE_VERSIONING = bool(os.environ.get("ENABLE_VERSIONING", True))
 if ENABLE_VERSIONING:

--- a/test_settings.py
+++ b/test_settings.py
@@ -5,8 +5,8 @@ from djangocms_url_manager.test_utils.polls.utils import (
     get_published_pages_objects,
 )
 
-
-EXTRA_INSTALLED_APPS = []
+CMS_CONFIRM_VERSION4 = True
+EXTRA_INSTALLED_APPS = ["app_helper"]
 ENABLE_VERSIONING = bool(os.environ.get("ENABLE_VERSIONING", True))
 if ENABLE_VERSIONING:
     EXTRA_INSTALLED_APPS.append("djangocms_versioning")
@@ -24,6 +24,7 @@ HELPER_SETTINGS = {
     "VERSIONING_CMS_MODELS_ENABLED": ENABLE_VERSIONING,
     "VERSIONING_URL_MANAGER_MODELS_ENABLED": ENABLE_VERSIONING,
     "MODERATING_URL_MANAGER_MODELS_ENABLED": ENABLE_MODERATION,
+    "CMS_CONFIRM_VERSION4": True,
     "TOP_INSTALLED_APPS": ["djangocms_url_manager"],
     "INSTALLED_APPS": [
         "djangocms_url_manager.test_utils.polls",
@@ -82,7 +83,7 @@ HELPER_SETTINGS = {
 
 
 def run():
-    from djangocms_helper import runner
+    from app_helper import runner
 
     runner.cms("djangocms_url_manager", extra_args=[])
 

--- a/tests/requirements/dj22_cms40.txt
+++ b/tests/requirements/dj22_cms40.txt
@@ -1,3 +1,0 @@
--r requirements_base.txt
-
-Django>=2.2,<3.0

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist =
     flake8
     isort
-    py{36,37,38}-dj{111,20,21}-sqlite-cms40-{default,versioning}
-    py{36,37,38,39}-dj{22}-sqlite-cms40-{default,versioning}
+    py{38,39}-dj{32}-sqlite-cms40-{default,versioning}
 
 skip_missing_interpreters=True
 
@@ -13,13 +12,11 @@ setenv =
 deps =
     -r {toxinidir}/tests/requirements/requirements_base.txt
 
-    dj22: -r {toxinidir}/tests/requirements/django-2_2.txt
+    dj32: -r {toxinidir}/tests/requirements/django-3_2.txt
 
     cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 
 basepython =
-    py36: python3.6
-    py37: python3.7
     py38: python3.8
     py39: python3.9
 
@@ -31,8 +28,8 @@ commands =
 
 [testenv:flake8]
 commands = flake8
-basepython = python3.6
+basepython = python3.9
 
 [testenv:isort]
 commands = isort --extra-builtin mock --recursive --check-only --diff {toxinidir}
-basepython = python3.6
+basepython = python3.9


### PR DESCRIPTION
Dropping support for old/no longer maintained versions of Python and Django. Please see the 4.0.x branch for those still wishing to use Django 2.2 or Python <3.8. 

Also switching from djangocms_app_helper to django_app_helper.